### PR TITLE
IDNA fast path for ASCII

### DIFF
--- a/.github/workflows/pushed.yaml
+++ b/.github/workflows/pushed.yaml
@@ -18,6 +18,6 @@ jobs:
       - uses: 'actions/checkout@v4'
       - uses: 'actions/setup-dotnet@v4'
         with:
-          dotnet-version: '8.x'
+          dotnet-version: '9.x'
       - name: 'Run tests'
         run: dotnet test -c ${{ matrix.configuration }}

--- a/src/Dubzer.WhatwgUrl.Codegen/Dubzer.WhatwgUrl.Codegen.csproj
+++ b/src/Dubzer.WhatwgUrl.Codegen/Dubzer.WhatwgUrl.Codegen.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
+        <TargetFramework>net9.0</TargetFramework>
     </PropertyGroup>
 </Project>

--- a/src/Dubzer.WhatwgUrl.Codegen/Status.cs
+++ b/src/Dubzer.WhatwgUrl.Codegen/Status.cs
@@ -6,7 +6,5 @@ public enum IdnaStatus
     Ignored,
     Mapped,
     Deviation,
-    Disallowed,
-    DisallowedSTD3Valid,
-    DisallowedSTD3Mapped
+    Disallowed
 }

--- a/src/Dubzer.WhatwgUrl/BclInternal/ParseNumbers.cs
+++ b/src/Dubzer.WhatwgUrl/BclInternal/ParseNumbers.cs
@@ -1,0 +1,155 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Dubzer.WhatwgUrl.BclInternal;
+
+/// <summary>Methods for parsing numbers and strings.</summary>
+internal static class ParseNumbers
+{
+    private const int TreatAsUnsigned = 0x0200;
+    internal const int IsTight = 0x1000;
+
+    public static long StringToLong(ReadOnlySpan<char> s, int radix, int flags)
+    {
+        int i = 0;
+        int r = radix;
+        int length = s.Length;
+
+        // Check for a sign
+        int sign = 1;
+        if (s[i] == '-')
+        {
+            if (r != 10)
+                throw new ArgumentException();
+
+            if ((flags & TreatAsUnsigned) != 0)
+                throw new OverflowException();
+
+            sign = -1;
+            i++;
+        }
+        else if (s[i] == '+')
+        {
+            i++;
+        }
+
+        if (radix is -1 or 16 && (i + 1 < length) && s[i] == '0')
+        {
+            if (s[i + 1] == 'x' || s[i + 1] == 'X')
+            {
+                r = 16;
+                i += 2;
+            }
+        }
+
+        int grabNumbersStart = i;
+        long result = GrabLongs(r, s, ref i, (flags & TreatAsUnsigned) != 0);
+
+        // Check if they passed us a string with no parsable digits.
+        if (i == grabNumbersStart)
+            throw new FormatException();
+
+        if ((flags & IsTight) != 0)
+        {
+            // If we've got effluvia left at the end of the string, complain.
+            if (i < length)
+                throw new FormatException();
+        }
+
+        // Return the value properly signed.
+        if ((ulong)result == 0x8000000000000000 && sign == 1 && r == 10 && ((flags & TreatAsUnsigned) == 0))
+            throw new OverflowException();
+
+        if (r == 10)
+        {
+            result *= sign;
+        }
+
+        return result;
+    }
+
+    private static long GrabLongs(int radix, ReadOnlySpan<char> s, ref int i, bool isUnsigned)
+    {
+        ulong result = 0;
+        ulong maxVal;
+
+        // Allow all non-decimal numbers to set the sign bit.
+        if (radix == 10 && !isUnsigned)
+        {
+            maxVal = 0x7FFFFFFFFFFFFFFF / 10;
+
+            // Read all of the digits and convert to a number
+            while (i < s.Length && IsDigit(s[i], radix, out int value))
+            {
+                // Check for overflows - this is sufficient & correct.
+                if (result > maxVal || ((long)result) < 0)
+                    throw new OverflowException();
+
+                result = result * (ulong)radix + (ulong)value;
+                i++;
+            }
+
+            if ((long)result < 0 && result != 0x8000000000000000)
+                throw new OverflowException();
+        }
+        else
+        {
+            Debug.Assert(radix is 2 or 8 or 10 or 16);
+            maxVal =
+                radix switch
+                {
+                    10 => 0xffffffffffffffff / 10,
+                    16 => 0xffffffffffffffff / 16,
+                    8 => 0xffffffffffffffff / 8,
+                    _ => 0xffffffffffffffff / 2
+                };
+
+            // Read all of the digits and convert to a number
+            while (i < s.Length && IsDigit(s[i], radix, out int value))
+            {
+                // Check for overflows - this is sufficient & correct.
+                if (result > maxVal)
+                    throw new OverflowException();
+
+                ulong temp = result * (ulong)radix + (ulong)value;
+
+                if (temp < result) // this means overflow as well
+                    throw new OverflowException();
+
+                result = temp;
+                i++;
+            }
+        }
+
+        return (long)result;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsDigit(char c, int radix, out int result)
+    {
+        int tmp;
+        if ((uint)(c - '0') <= 9)
+        {
+            result = tmp = c - '0';
+        }
+        else if ((uint)(c - 'A') <= 'Z' - 'A')
+        {
+            result = tmp = c - 'A' + 10;
+        }
+        else if ((uint)(c - 'a') <= 'z' - 'a')
+        {
+            result = tmp = c - 'a' + 10;
+        }
+        else
+        {
+            result = -1;
+            return false;
+        }
+
+        return tmp < radix;
+    }
+}

--- a/src/Dubzer.WhatwgUrl/HostParser.cs
+++ b/src/Dubzer.WhatwgUrl/HostParser.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Buffers;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Dubzer.WhatwgUrl.Uts46;
 
@@ -20,25 +21,28 @@ internal static class HostParser
     ]);
 
     // https://url.spec.whatwg.org/#ends-in-a-number-checker
-    private static bool EndsInANumber(string input)
+    private static bool EndsInANumber(ReadOnlySpan<char> input)
     {
-        var parts = input.Split('.');
+        // 1. Let parts be the result of strictly splitting input on U+002E (.).
+        var lastPartOffset = input.LastIndexOf('.');
 
-        var last = parts[^1];
-        if (string.IsNullOrEmpty(last))
+        // 2. If the last item in parts is the empty string, then:
+        if (lastPartOffset == input.Length - 1)
         {
-            if (parts.Length == 1)
-                return false;
+            input = input[..^1];
 
-            last = parts[^2];
+            // 1. If parts’s size is 1, then return false.
+            lastPartOffset = input.LastIndexOf('.');
+            if (lastPartOffset == -1 && lastPartOffset == input.Length - 1)
+                return false;
         }
 
-        var lastSpan = last.AsSpan();
+        input = input[(lastPartOffset + 1)..];
 
-        if (!string.IsNullOrEmpty(last) && !lastSpan.ContainsAnyExceptInRange('0', '9'))
+        if (input.Length > 0 && !input.ContainsAnyExceptInRange('0', '9'))
             return true;
 
-        return Ipv4Parser.ParseNumber(last) != -1;
+        return Ipv4Parser.ParseNumber(input) != -1;
     }
 
     // https://url.spec.whatwg.org/#concept-opaque-host-parser
@@ -55,6 +59,9 @@ internal static class HostParser
 
         return Result<string>.Success(sb.ToString());
     }
+
+    // characters that are not allowed for executing fast path
+    private static readonly SearchValues<char> FastPathInvalid = SearchValues.Create("-%");
 
     // https://url.spec.whatwg.org/#host-parsing
     public static Result<string> Parse(string input, bool isOpaque)
@@ -77,14 +84,55 @@ internal static class HostParser
         if (isOpaque)
             return ParseOpaqueHost(input);
 
-        // 4.Let domain be the result of running UTF-8 decode without BOM on the percent-decoding of input.
-        var domain = Utf8WithoutBom.GetString(PercentEncoding.PercentDecode(input));
+        var span = input.AsSpan();
 
-        var asciiDomain = Idna.ToAscii(domain);
-        if (string.IsNullOrEmpty(asciiDomain))
-            return Result<string>.Failure(UrlErrorCode.DomainToAscii);
+        var asciiFastPath = false;
 
-        var asciiDomainSpan = asciiDomain.AsSpan();
+        // additional validation for fast path
+        // TODO: SearchValues<ReadOnlySpan<char>> can be used when .NET 9 is targeted
+        if (input.Length < Consts.MaxLengthOnStack.Char
+            && RuntimeHelpers.TryEnsureSufficientExecutionStack()
+            && Ascii.IsValid(input))
+        {
+            var currentIndex = 0;
+            while (true)
+            {
+                var index = span[currentIndex..].IndexOfAny(FastPathInvalid);
+                if (index == -1)
+                {
+                    asciiFastPath = true;
+                    break;
+                }
+
+                if (span[index] == '%' ||
+                    // span[index..] is ['-', '-', ..]
+                    span[index] == '-' && span.Length > index + 1 && span[index + 1] == '-')
+                    break;
+
+                currentIndex += index + 1;
+            }
+        }
+
+        scoped ReadOnlySpan<char> asciiDomainSpan;
+        if (asciiFastPath)
+        {
+            Span<char> buf = stackalloc char[input.Length];
+            span.ToLowerInvariant(buf);
+
+            asciiDomainSpan = buf;
+        }
+        else
+        {
+            // 4.Let domain be the result of running UTF-8 decode without BOM on the percent-decoding of input.
+            var domain = Utf8WithoutBom.GetString(PercentEncoding.PercentDecode(input));
+
+            var asciiDomain = Idna.ToAscii(domain);
+            if (string.IsNullOrEmpty(asciiDomain))
+                return Result<string>.Failure(UrlErrorCode.DomainToAscii);
+
+            asciiDomainSpan = asciiDomain.AsSpan();
+        }
+
         // 7. If asciiDomain contains a forbidden domain code point, ..., return failure.
         if (asciiDomainSpan.ContainsAny(ForbiddenDomainCodePoints))
             return Result<string>.Failure(UrlErrorCode.DomainInvalidCodePoint);
@@ -92,9 +140,9 @@ internal static class HostParser
         // Return IPv6 as a string here, unlike the spec,
         // which states to serialize a number to a string
         // only when serializing the host.
-        if (EndsInANumber(asciiDomain))
-            return Ipv4Parser.Parse(asciiDomain);
+        if (EndsInANumber(asciiDomainSpan))
+            return Ipv4Parser.Parse(asciiDomainSpan.ToString());
 
-        return Result<string>.Success(asciiDomain.ToLowerInvariant());
+        return Result<string>.Success(asciiDomainSpan.ToString());
     }
 }

--- a/src/Dubzer.WhatwgUrl/Ipv4Parser.cs
+++ b/src/Dubzer.WhatwgUrl/Ipv4Parser.cs
@@ -2,6 +2,7 @@
 using System.Buffers;
 using System.Collections.Generic;
 using System.Text;
+using Dubzer.WhatwgUrl.BclInternal;
 
 namespace Dubzer.WhatwgUrl;
 
@@ -90,9 +91,9 @@ internal static class Ipv4Parser
     }
 
     /// <returns>-1 when invalid</returns>
-    internal static long ParseNumber(string input)
+    internal static long ParseNumber(ReadOnlySpan<char> input)
     {
-        if (string.IsNullOrEmpty(input))
+        if (input.Length == 0)
             return -1;
 
         var numBase = 10;   // R in spec
@@ -114,14 +115,13 @@ internal static class Ipv4Parser
             }
         }
 
-        var span = input.AsSpan();
 #pragma warning disable CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
         var valid = numBase switch
 #pragma warning restore CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
         {
-            8 => !span[1..].ContainsAnyExceptInRange('0', '7'),
-            10 => !span.ContainsAnyExceptInRange('0', '9'),
-            16 => !span[2..].ContainsAnyExcept(HexDigitSearchValues)
+            8 => !input[1..].ContainsAnyExceptInRange('0', '7'),
+            10 => !input.ContainsAnyExceptInRange('0', '9'),
+            16 => !input[2..].ContainsAnyExcept(HexDigitSearchValues)
         };
 
         if (!valid)
@@ -135,7 +135,6 @@ internal static class Ipv4Parser
             // MaxValue so IP would not be valid on the check later
             return long.MaxValue;
 
-        // this should not throw an exception...
-        return Convert.ToInt64(input, numBase);
+        return ParseNumbers.StringToLong(input, numBase, ParseNumbers.IsTight);
     }
 }


### PR DESCRIPTION
We can skip most of the domain processing if the input is a valid ASCII string. 
This PR also removes any reduntant heap allocation for ASCII, so the only thing heap allocated in `HostParser.Parse` for a regular domain is a result itself.

|  Benchmark results |
|--------|
| Before |
| ![image](https://github.com/user-attachments/assets/46de0261-4ca7-434b-b00d-7caba1f42390) |
| After |
| ![image](https://github.com/user-attachments/assets/9747bce5-7b1e-4e75-8e1b-a5c2f824494a) | 